### PR TITLE
Please add some POP3 server

### DIFF
--- a/fs-build/netkit-tweaks/disabled-services
+++ b/fs-build/netkit-tweaks/disabled-services
@@ -25,4 +25,4 @@ dnsmasq
 quagga
 dbus
 pdns-recursor
-
+popa3d

--- a/fs-build/packages-list
+++ b/fs-build/packages-list
@@ -115,6 +115,7 @@ perl-modules
 pimd
 pipsecd
 portmap
+popa3d
 ppp
 procmail
 procps


### PR DESCRIPTION
I cannot find any pop3 server in netkit filesystem.

This commit adds simple pop3 server called 'popa3d'  to installed package list and disabled service list. 
