### PR TITLE
Please add Tcpick --- a tool to view tcpdump dumps.

### DIFF
--- a/fs-build/packages-list
+++ b/fs-build/packages-list
@@ -150,6 +150,7 @@ sysvinit
 tar
 tcpd
 tcpdump
+tcpick
 tcpreen
 tcpreplay
 tcpslice


### PR DESCRIPTION
Tcpick is a tool to view tcpdump dump files in human-readable format.
While it is possible to view them on host machine,  using tcpick within a Netkit system is a more convenient approach.
