### PR TITLE
Having make and gcc out-of-the-box could be nice.

### DIFF
--- a/fs-build/packages-list
+++ b/fs-build/packages-list
@@ -47,6 +47,7 @@ file
 findutils
 freeradius
 ftp
+gcc
 grep
 groff
 groff-base
@@ -74,6 +75,7 @@ lrzsz
 lsof
 lynx
 mailx
+make
 makedev
 man-db
 manpages


### PR DESCRIPTION
Writing, compiling and running simple C programs is essential for studying TCP. 
Having gcc and make packages is enough for compiling simple programs working with network sockets.

While this is rather optional, I still add this filesystem request. 
